### PR TITLE
Fix code scanning alert no. 603: Database query built from user-controlled sources

### DIFF
--- a/backend/routes/ticketRoutes.js
+++ b/backend/routes/ticketRoutes.js
@@ -96,7 +96,10 @@ router.post("/tickets", auth, async (req, res) => {
 router.patch("/tickets/:id", adminAuth, async (req, res) => {
   try {
     const { id } = req.params;
-    const updates = req.body;
+    const updates = {};
+    if (req.body.assignedTo && typeof req.body.assignedTo === 'string') {
+      updates.assignedTo = req.body.assignedTo;
+    }
 
     // Validate ObjectId
     if (!mongoose.Types.ObjectId.isValid(id)) {


### PR DESCRIPTION
Fixes [https://github.com/KovacevicAleksa/BookingEvents/security/code-scanning/603](https://github.com/KovacevicAleksa/BookingEvents/security/code-scanning/603)

To fix the problem, we need to ensure that the `updates` object is sanitized before using it in the MongoDB query. This can be done by validating that the values in the `updates` object are of the expected type and do not contain any malicious content. Specifically, we should ensure that the `assignedTo` field, if present, is a string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
